### PR TITLE
change the path of the datasets and datasets-config to take into acco…

### DIFF
--- a/dafter/fetcher/constants.py
+++ b/dafter/fetcher/constants.py
@@ -6,8 +6,17 @@ import os
 HOME = os.path.expanduser("~")
 CURRENT_FOLDER = "/".join(__file__.split("/")[:-1])
 
-DATASETS_CONFIG_FOLDER = os.path.join(CURRENT_FOLDER, "..", "datasets-configs")
-DATASETS_FOLDER = os.path.join(HOME, ".dafter")
+#DATASETS_CONFIG_FOLDER = os.path.join(CURRENT_FOLDER, "..", "datasets-configs")
+
+# see https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+
+if 'XDG_DATA_HOME' in os.environ:
+    DATASETS_FOLDER = os.path.join(os.environ['XDG_DATA_HOME'], "dafter")
+    DATASETS_CONFIG_FOLDER = os.path.join(os.environ['XDG_DATA_HOME'], "dafter", "datasets-configs")
+else:
+    DATASETS_FOLDER = os.path.join(HOME, ".local", "share", "dafter")
+    DATASETS_CONFIG_FOLDER = os.path.join(DATASETS_FOLDER, "datasets-configs")
+
 VERSION_FILE = os.path.join(CURRENT_FOLDER, "..", "VERSION.txt")
 
 __all__ = ["DATASETS_CONFIG_FOLDER", "DATASETS_FOLDER", "VERSION_FILE"]


### PR DESCRIPTION
…unt XDG_DATA_HOME, and use .local/share otherwise

I propose to use .local/share or $XDG_DATA_HOME (https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) as a base directory for both datasets and datasets-config.

But I am not sure if this will will not break with the install script (!), unless it relies on constant.py


